### PR TITLE
Implement dark mode and tabular match view

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -13,6 +13,7 @@ function App() {
   const [selectedType, setSelectedType] = useState<TournamentType | null>(null);
   const [tournament, setTournament] = useState<Tournament | null>(null);
   const [teams, setTeams] = useState<Team[]>([]);
+  const [darkMode, setDarkMode] = useState(false);
 
   // Sauvegarder l'état dans le localStorage
   useEffect(() => {
@@ -32,6 +33,7 @@ function App() {
             matches: data.tournament.matches.map((match: any) => ({
               ...match,
               createdAt: new Date(match.createdAt),
+              terrain: match.terrain,
               completedAt: match.completedAt ? new Date(match.completedAt) : undefined
             }))
           });
@@ -51,6 +53,22 @@ function App() {
   }, []);
 
   useEffect(() => {
+    const savedMode = localStorage.getItem('dark-mode');
+    if (savedMode) {
+      setDarkMode(JSON.parse(savedMode));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (darkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    localStorage.setItem('dark-mode', JSON.stringify(darkMode));
+  }, [darkMode]);
+
+  useEffect(() => {
     if (appState === 'tournament' && tournament) {
       localStorage.setItem('petanque-tournament', JSON.stringify({ tournament }));
     } else if (appState === 'team-setup' && selectedType) {
@@ -62,6 +80,15 @@ function App() {
     setSelectedType(type);
     setAppState('team-setup');
   };
+
+  const DarkModeButton = () => (
+    <button
+      onClick={() => setDarkMode(!darkMode)}
+      className="fixed top-4 right-4 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 px-3 py-1 rounded"
+    >
+      {darkMode ? 'Mode clair' : 'Mode sombre'}
+    </button>
+  );
 
   const startTournament = () => {
     if (!canStartTournament(teams) || !selectedType) return;
@@ -147,27 +174,36 @@ function App() {
   const canAdvanceRound = tournament ? isRoundComplete(tournament.matches, tournament.currentRound) : false;
 
   if (appState === 'type-selection') {
-    return <TournamentTypeSelector onTypeSelect={handleTypeSelect} />;
+    return (
+      <>
+        <DarkModeButton />
+        <TournamentTypeSelector onTypeSelect={handleTypeSelect} />
+      </>
+    );
   }
 
   if (appState === 'team-setup' && selectedType) {
     return (
-      <TeamSetup
-        tournamentType={selectedType}
-        teams={teams}
-        onTeamsChange={setTeams}
-        onStartTournament={startTournament}
-        onBack={backToTypeSelection}
-        canStart={canStartTournament(teams)}
-      />
+      <>
+        <DarkModeButton />
+        <TeamSetup
+          tournamentType={selectedType}
+          teams={teams}
+          onTeamsChange={setTeams}
+          onStartTournament={startTournament}
+          onBack={backToTypeSelection}
+          canStart={canStartTournament(teams)}
+        />
+      </>
     );
   }
 
   if (appState === 'tournament' && tournament) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-green-50 to-emerald-100">
+      <div className="min-h-screen bg-gradient-to-br from-green-50 to-emerald-100 dark:from-gray-800 dark:to-gray-900">
+        <DarkModeButton />
         {/* Header */}
-        <header className="bg-white shadow-lg">
+        <header className="bg-white dark:bg-gray-800 shadow-lg">
           <div className="max-w-7xl mx-auto px-6 py-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">

--- a/project/src/components/TournamentView.tsx
+++ b/project/src/components/TournamentView.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
-import { Trophy, Medal, Award, TrendingUp } from 'lucide-react';
-import { Tournament, TeamStats } from '../types';
+import React, { useState } from 'react';
+import { Tournament, Team } from '../types';
 import { getTeamRankings } from '../utils/tournamentLogic';
-import MatchCard from './MatchCard';
 
 interface TournamentViewProps {
   tournament: Tournament;
@@ -12,141 +10,150 @@ interface TournamentViewProps {
 }
 
 export default function TournamentView({ tournament, onScoreUpdate, onNextRound, canAdvanceRound }: TournamentViewProps) {
-  const rankings = getTeamRankings(tournament.teams, tournament.matches);
-  const currentRoundMatches = tournament.matches.filter(match => match.round === tournament.currentRound);
-  const completedMatches = tournament.matches.filter(match => match.completed);
+  const [activeTab, setActiveTab] = useState<'teams' | 'matches' | 'results'>('teams');
+  const [scores, setScores] = useState<Record<string, { s1: string; s2: string }>>({});
 
-  const getRankIcon = (index: number) => {
-    switch (index) {
-      case 0: return <Trophy className="text-yellow-500" size={20} />;
-      case 1: return <Medal className="text-gray-400" size={20} />;
-      case 2: return <Award className="text-amber-600" size={20} />;
-      default: return <TrendingUp className="text-gray-400" size={16} />;
-    }
+  const rankings = getTeamRankings(tournament.teams, tournament.matches);
+  const rounds = Array.from(new Set(tournament.matches.map(m => m.round))).sort((a, b) => a - b);
+
+  const teamNumber = (team: Team) => tournament.teams.findIndex(t => t.id === team.id) + 1;
+
+  const handleChange = (id: string, field: 's1' | 's2', value: string) => {
+    setScores(prev => ({ ...prev, [id]: { s1: prev[id]?.s1 || '', s2: prev[id]?.s2 || '', [field]: value } }));
   };
 
-  const getTeamDisplayName = (team: any, index: number) => {
-    return `Équipe ${index + 1}`;
+  const handleSave = (matchId: string) => {
+    const entry = scores[matchId];
+    if (!entry) return;
+    const s1 = parseInt(entry.s1);
+    const s2 = parseInt(entry.s2);
+    if (!isNaN(s1) && !isNaN(s2) && (s1 === 13 || s2 === 13) && s1 !== s2) {
+      onScoreUpdate(matchId, s1, s2);
+      setScores(prev => ({ ...prev, [matchId]: { s1: '', s2: '' } }));
+    }
   };
 
   return (
     <div className="max-w-7xl mx-auto p-6">
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Classement */}
-        <div className="lg:col-span-1">
-          <div className="bg-white rounded-xl shadow-lg p-6 sticky top-6">
-            <div className="flex items-center gap-3 mb-6">
-              <Trophy className="text-amber-600" size={24} />
-              <h2 className="text-2xl font-bold text-gray-800">Classement</h2>
-            </div>
-
-            <div className="space-y-3">
-              {rankings.map((stats: TeamStats, index: number) => (
-                <div key={stats.team.id} className={`p-4 rounded-lg border ${
-                  index === 0 ? 'bg-yellow-50 border-yellow-200' :
-                  index === 1 ? 'bg-gray-50 border-gray-200' :
-                  index === 2 ? 'bg-amber-50 border-amber-200' :
-                  'bg-white border-gray-100'
-                }`}>
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="flex items-center gap-2">
-                      {getRankIcon(index)}
-                      <span className="font-bold text-gray-800">#{index + 1}</span>
-                    </div>
-                    <div className="text-right">
-                      <div className="text-sm font-medium text-gray-600">
-                        {stats.wins}V - {stats.losses}D
-                      </div>
-                      <div className="text-xs text-gray-500">
-                        {Math.round(stats.winRate * 100)}% victoires
-                      </div>
-                    </div>
-                  </div>
-                  
-                  <h3 className="font-semibold text-gray-800 mb-1">{getTeamDisplayName(stats.team, index)}</h3>
-                  <p className="text-sm text-gray-600 mb-2">{stats.team.players.join(' • ')}</p>
-                  
-                  <div className="flex justify-between text-sm text-gray-600">
-                    <span>Points: {stats.totalPointsFor} - {stats.totalPointsAgainst}</span>
-                    <span className={`font-medium ${
-                      stats.pointsDifference > 0 ? 'text-green-600' : 
-                      stats.pointsDifference < 0 ? 'text-red-600' : 'text-gray-600'
-                    }`}>
-                      {stats.pointsDifference > 0 ? '+' : ''}{stats.pointsDifference}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            {/* Statistiques du tournoi */}
-            <div className="mt-6 pt-6 border-t">
-              <h3 className="font-semibold text-gray-800 mb-3">Statistiques</h3>
-              <div className="space-y-2 text-sm text-gray-600">
-                <div className="flex justify-between">
-                  <span>Type:</span>
-                  <span className="font-medium">{tournament.type.name}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>Round actuel:</span>
-                  <span className="font-medium">{tournament.currentRound}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>Matchs joués:</span>
-                  <span className="font-medium">{completedMatches.length}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>Équipes:</span>
-                  <span className="font-medium">{tournament.teams.length}</span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Matchs */}
-        <div className="lg:col-span-2">
-          <div className="flex items-center justify-between mb-6">
-            <h2 className="text-2xl font-bold text-gray-800">
-              Round {tournament.currentRound}
-            </h2>
-            
-            {canAdvanceRound && (
-              <button
-                onClick={onNextRound}
-                className="bg-green-600 text-white px-6 py-2 rounded-lg font-medium hover:bg-green-700 transition-colors"
-              >
-                Round suivant
-              </button>
-            )}
-          </div>
-
-          {currentRoundMatches.length > 0 ? (
-            <div className="space-y-6">
-              {currentRoundMatches.map((match) => (
-                <MatchCard
-                  key={match.id}
-                  match={match}
-                  onScoreUpdate={onScoreUpdate}
-                />
-              ))}
-            </div>
-          ) : (
-            <div className="bg-white rounded-xl shadow-lg p-8 text-center">
-              <Trophy className="text-gray-400 mx-auto mb-4" size={48} />
-              <h3 className="text-xl font-semibold text-gray-800 mb-2">Tournoi terminé!</h3>
-              <p className="text-gray-600">
-                Félicitations à <strong>{getTeamDisplayName(rankings[0]?.team, 0)}</strong> pour la victoire!
-              </p>
-              <div className="mt-4 p-4 bg-yellow-50 rounded-lg">
-                <p className="text-sm text-gray-600">
-                  Joueurs gagnants: <strong>{rankings[0]?.team.players.join(', ')}</strong>
-                </p>
-              </div>
-            </div>
-          )}
-        </div>
+      <div className="mb-6 flex gap-2">
+        <button onClick={() => setActiveTab('teams')} className={`px-4 py-2 rounded ${activeTab === 'teams' ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>Équipes</button>
+        <button onClick={() => setActiveTab('matches')} className={`px-4 py-2 rounded ${activeTab === 'matches' ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>Matchs</button>
+        <button onClick={() => setActiveTab('results')} className={`px-4 py-2 rounded ${activeTab === 'results' ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>Résultats</button>
       </div>
+
+      {activeTab === 'teams' && (
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-4">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b">
+                <th className="p-2">#</th>
+                <th className="p-2">Joueurs</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tournament.teams.map((team, index) => (
+                <tr key={team.id} className="border-b last:border-b-0">
+                  <td className="p-2">{index + 1}</td>
+                  <td className="p-2">{team.players.join(' • ')}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {activeTab === 'matches' && (
+        <div className="space-y-8">
+          {rounds.map(round => {
+            const matches = tournament.matches.filter(m => m.round === round);
+            return (
+              <div key={round} className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-4">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-xl font-bold">Round {round}</h2>
+                  {round === tournament.currentRound && canAdvanceRound && (
+                    <button onClick={onNextRound} className="bg-green-600 text-white px-4 py-1 rounded">Round suivant</button>
+                  )}
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-left">
+                    <thead>
+                      <tr className="border-b">
+                        <th className="p-2">Éq.</th>
+                        <th className="p-2">Joueurs</th>
+                        <th className="p-2">Score</th>
+                        <th className="p-2">Score</th>
+                        <th className="p-2">Adversaires</th>
+                        <th className="p-2">Éq.</th>
+                        <th className="p-2">Terrain</th>
+                        <th className="p-2"></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {matches.map(match => {
+                        const entry = scores[match.id] || { s1: match.score1?.toString() || '', s2: match.score2?.toString() || '' };
+                        const editable = !match.completed && round === tournament.currentRound;
+                        return (
+                          <tr key={match.id} className="border-b last:border-b-0">
+                            <td className="p-2">{teamNumber(match.team1)}</td>
+                            <td className="p-2">{match.team1.players.join(' • ')}</td>
+                            <td className="p-2">
+                              {editable ? (
+                                <input type="number" value={entry.s1} onChange={e => handleChange(match.id, 's1', e.target.value)} className="w-16 p-1 border rounded" />
+                              ) : (
+                                match.score1 ?? '-'
+                              )}
+                            </td>
+                            <td className="p-2">
+                              {editable ? (
+                                <input type="number" value={entry.s2} onChange={e => handleChange(match.id, 's2', e.target.value)} className="w-16 p-1 border rounded" />
+                              ) : (
+                                match.score2 ?? '-'
+                              )}
+                            </td>
+                            <td className="p-2">{match.team2.players.join(' • ')}</td>
+                            <td className="p-2">{teamNumber(match.team2)}</td>
+                            <td className="p-2">{match.terrain}</td>
+                            <td className="p-2">
+                              {editable && (Number(entry.s1) === 13 || Number(entry.s2) === 13) && Number(entry.s1) !== Number(entry.s2) && (
+                                <button onClick={() => handleSave(match.id)} className="bg-green-600 text-white px-2 py-1 rounded">OK</button>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {activeTab === 'results' && (
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-4">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b">
+                <th className="p-2">#</th>
+                <th className="p-2">Joueurs</th>
+                <th className="p-2">Victoires</th>
+                <th className="p-2">Diff.</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rankings.map((stats, index) => (
+                <tr key={stats.team.id} className="border-b last:border-b-0">
+                  <td className="p-2">{teamNumber(stats.team)}</td>
+                  <td className="p-2">{stats.team.players.join(' • ')}</td>
+                  <td className="p-2">{stats.wins}</td>
+                  <td className="p-2">{stats.pointsDifference > 0 ? '+' : ''}{stats.pointsDifference}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/project/src/types.ts
+++ b/project/src/types.ts
@@ -10,6 +10,7 @@ export interface Match {
   team2: Team;
   score1?: number;
   score2?: number;
+  terrain: number;
   round: number;
   completed: boolean;
   createdAt: Date;

--- a/project/src/utils/tournamentLogic.ts
+++ b/project/src/utils/tournamentLogic.ts
@@ -101,11 +101,12 @@ export function generateNextMatches(teams: Team[], existingMatches: Match[], rou
 
     if (bestMatchIndex !== -1) {
       const team2Stats = availableTeams.splice(bestMatchIndex, 1)[0];
-      
+
       newMatches.push({
         id: generateId(),
         team1: team1Stats.team,
         team2: team2Stats.team,
+        terrain: newMatches.length + 1,
         round,
         completed: false,
         createdAt: new Date()

--- a/project/tailwind.config.js
+++ b/project/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode
- allow toggling dark mode in the UI
- persist dark mode preference
- add terrain field to matches and generate it
- store terrain field when restoring state
- redesign tournament view with tabs for teams, matches and results
- display matches in editable tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506e89dda88324b9386304b339e0c2