### PR TITLE
Improve layout and background style

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -171,7 +171,7 @@ function App() {
 
   if (appState === 'tournament' && tournament) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-sky-50 to-orange-100">
+      <div className="min-h-screen bg-gradient-to-br from-green-50 via-blue-50 to-green-100">
         {/* Header */}
         <header className="bg-white shadow-lg">
           <div className="max-w-7xl mx-auto px-6 py-4">

--- a/project/src/components/TeamSetup.tsx
+++ b/project/src/components/TeamSetup.tsx
@@ -59,7 +59,7 @@ export default function TeamSetup({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-sky-50 to-orange-100">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-blue-50 to-green-100">
       {/* Header */}
       <header className="bg-white shadow-lg">
         <div className="max-w-7xl mx-auto px-6 py-4">
@@ -132,12 +132,12 @@ export default function TeamSetup({
 
             {/* Liste des équipes */}
             {teams.length > 0 && (
-              <div className="mb-8">
+              <div className="mb-8 text-center">
                 <h3 className="text-xl font-semibold text-gray-800 mb-4">
                   Équipes inscrites ({teams.length})
                 </h3>
                 
-                <div className="grid gap-4">
+                <div className="grid gap-4 max-w-3xl mx-auto">
                   {teams.map((team, index) => (
                     <div key={team.id} className="bg-gray-50 rounded-lg p-4 flex items-center justify-between">
                       <div>

--- a/project/src/components/TournamentTypeSelector.tsx
+++ b/project/src/components/TournamentTypeSelector.tsx
@@ -8,7 +8,7 @@ interface TournamentTypeSelectorProps {
 
 export default function TournamentTypeSelector({ onTypeSelect }: TournamentTypeSelectorProps) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-sky-50 to-orange-100">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-blue-50 to-green-100">
       {/* Header */}
       <header className="bg-white shadow-lg">
         <div className="max-w-7xl mx-auto px-6 py-4">

--- a/project/src/components/TournamentView.tsx
+++ b/project/src/components/TournamentView.tsx
@@ -53,11 +53,11 @@ export default function TournamentView({ tournament, onScoreUpdate, onNextRound,
       </div>
 
       {activeTab === 'teams' && (
-        <div className="bg-white rounded-xl shadow-lg p-4">
+        <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-6 max-w-3xl mx-auto">
           <div className="text-right mb-2">
             <button onClick={handlePrint} className="bg-blue-600 text-white px-3 py-1 rounded">Imprimer</button>
           </div>
-          <table className="w-full text-left">
+          <table className="w-full text-center">
             <thead>
               <tr className="border-b">
                 <th className="p-2">#</th>
@@ -90,7 +90,7 @@ export default function TournamentView({ tournament, onScoreUpdate, onNextRound,
             ))}
             <button onClick={handlePrint} className="ml-auto bg-blue-600 text-white px-3 py-1 rounded">Imprimer</button>
           </div>
-          <div className="bg-white rounded-xl shadow-lg p-4">
+          <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-6 max-w-5xl mx-auto">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-xl font-bold">Tour {activeRound}</h2>
               {activeRound === tournament.currentRound && canAdvanceRound && (
@@ -153,11 +153,11 @@ export default function TournamentView({ tournament, onScoreUpdate, onNextRound,
       )}
 
       {activeTab === 'results' && (
-        <div className="bg-white rounded-xl shadow-lg p-4">
+        <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-6 max-w-3xl mx-auto">
           <div className="text-right mb-2">
             <button onClick={handlePrint} className="bg-blue-600 text-white px-3 py-1 rounded">Imprimer</button>
           </div>
-          <table className="w-full text-left">
+          <table className="w-full text-center">
             <thead>
               <tr className="border-b">
                 <th className="p-2">#</th>


### PR DESCRIPTION
## Summary
- tweak background gradient colours across the app
- centre team and results tables and give all lists some borders
- keep teams list centred on setup screen

## Testing
- `npm test` (shows no tests)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508715d2648324a78c1f00b3f4835e